### PR TITLE
Add bottom margin  on <p> element in the editor view

### DIFF
--- a/src/app/components/editors/base-editor/terra-base-editor.component.glob.scss
+++ b/src/app/components/editors/base-editor/terra-base-editor.component.glob.scss
@@ -6,6 +6,11 @@ quill-editor
     .ql-container
     {
         background-color: var(--color-structure-0);
+
+        .ql-editor p
+        {
+            margin-bottom: 1rem;
+        }
     }
 
     .ql-snow.ql-toolbar


### PR DESCRIPTION
@plentymarkets/team-terra

### Definition of Done
Documentation
- [ ] Changelog
- [ ] Example (updated or created)
- [ ] JSDoc

Testing
- [ ] Unit Test (updated or created)
- [ ] Unit Test successful
- [ ] Person 1
- [ ] Person 2

Browser-Support
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Terra Basic Plugin
- [ ] Adapt changes


A "`<p>`" element always has a bottom margin (also in Ceres). This should also be displayed in the editor view to better estimate the result in Ceres. In addition, this could not be distinguished with a normal line break in the editor.